### PR TITLE
fix(django): removed username and password

### DIFF
--- a/generator/django/overrides/auth0-django-authlib/README.md
+++ b/generator/django/overrides/auth0-django-authlib/README.md
@@ -16,11 +16,12 @@ Install the required dependencies:
 pip install -r requirements.txt
 ```
 
-## Create Login Configuration and Update .env
+## Create Login Configuration and update .env
 
-Create your Affinidi OAuth Client at [Affinidi Portal](https://portal.affinidi.com/), make sure to add `https://{tenant-name}.us.auth0.com/login/callback` into Authorized redirect URIs.
+Create your Affinidi Login Configuration with the [Affinidi CLI](https://github.com/affinidi/affinidi-cli#set-up-affinidi-login-for-your-applications) or at [Affinidi Portal](https://portal.affinidi.com/), make sure to add `https://{tenant-name}.us.auth0.com/login/callback` into authorized redirect URIs.
 
 Please read the [setup login config guide](./docs/setup-login-config.md) to understand more about setting up login configuration in affinidi for Auth0.
+
 Also please refer the [configuration guide](./docs/configuration.md) to understand more about setting up login configuration in Auth0.
 
 Fill the client ID, secret and issuer URL in `.env` file
@@ -28,7 +29,7 @@ Fill the client ID, secret and issuer URL in `.env` file
 then run:
 
 ```
-python3 manage.py migrate
+python manage.py migrate
 ```
 
 ## Run
@@ -36,10 +37,10 @@ python3 manage.py migrate
 Start server with:
 
 ```
-python3 manage.py runserver
+python manage.py runserver
 ```
 
-Then visit: http://localhost:8000/
+Then visit: http://localhost:8000
 
 ## Read More
 

--- a/generator/django/overrides/auth0-django-authlib/django_reference_app/templates/index.html
+++ b/generator/django/overrides/auth0-django-authlib/django_reference_app/templates/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>Django Affinidi Integration Example</title>
+    <title>Affinidi Login Integration Example</title>
     <style>
         .container {
             width: 400px;
@@ -17,48 +17,14 @@
         .form-container h1 {
             text-align: center;
         }
-
-        .form-group {
-            margin-bottom: 15px;
-            margin-right: 10px;
-        }
-
-        .form-group label {
-            display: block;
-        }
-
-        .form-group input {
-            width: 100%;
-            padding: 10px;
-            border: 1px solid #ccc;
-            border-radius: 5px;
-        }
-
-        .form-group button {
-            width: 100%;
-            padding: 10px;
-            background: #007bff;
-            border: none;
-            color: #fff;
-            border-radius: 5px;
-            cursor: pointer;
-        }
     </style>
 </head>
 <body>
     <div class="container">
         <div class="form-container">
-            <h1>Insurance Login</h1>
+            <h1>Login with Affinidi Login through Auth0</h1>
             <form method="post" action="/login">
                 {% csrf_token %}
-                <div class="form-group">
-                    <label for="username">Username</label>
-                    <input type="text" id="username" name="username" placeholder="Enter your username">
-                </div>
-                <div class="form-group">
-                    <label for="password">Password</label>
-                    <input type="password" id="password" name "password" placeholder="Enter your password">
-                </div>
                 <button type="submit">Log In</button>
             </form>
         </div>

--- a/generator/django/overrides/auth0-django-authlib/django_reference_app/templates/loggedin.html
+++ b/generator/django/overrides/auth0-django-authlib/django_reference_app/templates/loggedin.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <title>Django Affinidi Integration Example</title>
+  <title>Affinidi Login Integration Example</title>
 </head>
 <body>
   <h1>Welcome {{session.userinfo.name}}!</h1>

--- a/generator/django/overrides/auth0-django-authlib/docs/configuration.md
+++ b/generator/django/overrides/auth0-django-authlib/docs/configuration.md
@@ -66,9 +66,9 @@ PROVIDER_ISSUER="https://my-fancy-project.eu.auth0.com"
 
 1.6. Scroll down and set:
 
-- **Allowed Callback URLs** to `http://localhost:{port_number}/callback`
-- **Allowed Logout URLs** to `http://localhost:{port_number}`
-- **Allowed Web Origins** to `http://localhost:{port_number}`
+- **Allowed Callback URLs** to `http://localhost:8000/callback`
+- **Allowed Logout URLs** to `http://localhost:8000`
+- **Allowed Web Origins** to `http://localhost:8000`
 
 ![Callback configuration](./images/auth0_callback_configuration.png)
 
@@ -118,11 +118,3 @@ function fetchUserProfile(accessToken, context, callback) {
 3.4. Click **"Create"** and enable the connection for your application.
 
 ![Enable connection](./images/auth0_enable_connection.png)
-
-3.5. (Optional) Set the connection name in the reference application
-
-Setting this environment variable will allow you to bypass Auth0's window for selecting the social connector. Set this variable to the name you assigned to your social connector on the step 3.1.
-
-```ini
-NEXT_PUBLIC_SOCIAL_CONNECTOR_NAME="Affinidi"
-```

--- a/generator/django/template/.gitignore
+++ b/generator/django/template/.gitignore
@@ -1,0 +1,15 @@
+# Python
+__pycache__/
+*.py[cod]
+
+# Django
+db.sqlite3
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/generator/django/template/README.md
+++ b/generator/django/template/README.md
@@ -16,9 +16,9 @@ Install the required dependencies:
 pip install -r requirements.txt
 ```
 
-## Create Login Configuration and Update .env
+## Create Login Configuration and update .env
 
-Create your Affinidi OAuth Client at [Affinidi Portal](https://portal.affinidi.com/), make sure to add `http://localhost:{port_number}/auth/` into Authorized redirect URIs.
+Create your Affinidi Login Configuration with the [Affinidi CLI](https://github.com/affinidi/affinidi-cli#set-up-affinidi-login-for-your-applications) or at [Affinidi Portal](https://portal.affinidi.com/), make sure to add `http://localhost:8000/callback` into authorized redirect URIs.
 
 Please read the [setup login config guide](./docs/setup-login-config.md) to understand more about setting up login configuration.
 
@@ -27,7 +27,7 @@ Fill the client ID, secret and issuer URL in `.env` file
 then run:
 
 ```
-python3 manage.py migrate
+python manage.py migrate
 ```
 
 ## Run
@@ -35,10 +35,10 @@ python3 manage.py migrate
 Start server with:
 
 ```
-python3 manage.py runserver
+python manage.py runserver
 ```
 
-Then visit: http://localhost:8000/
+Then visit: http://localhost:8000
 
 ## Read More
 

--- a/generator/django/template/django_reference_app/settings.py
+++ b/generator/django/template/django_reference_app/settings.py
@@ -56,7 +56,7 @@ ROOT_URLCONF = 'django_reference_app.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [TEMPLATE_DIR],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -66,7 +66,6 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
             ],
         },
-        'DIRS': [TEMPLATE_DIR],
     },
 ]
 

--- a/generator/django/template/django_reference_app/templates/index.html
+++ b/generator/django/template/django_reference_app/templates/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>Django Affinidi Integration Example</title>
+    <title>Affinidi Login Integration Example</title>
     <style>
         .container {
             width: 400px;
@@ -16,32 +16,6 @@
 
         .form-container h1 {
             text-align: center;
-        }
-
-        .form-group {
-            margin-bottom: 15px;
-            margin-right: 10px;
-        }
-
-        .form-group label {
-            display: block;
-        }
-
-        .form-group input {
-            width: 100%;
-            padding: 10px;
-            border: 1px solid #ccc;
-            border-radius: 5px;
-        }
-
-        .form-group button {
-            width: 100%;
-            padding: 10px;
-            background: #007bff;
-            border: none;
-            color: #fff;
-            border-radius: 5px;
-            cursor: pointer;
         }
         
         .affinidi-login-div {
@@ -73,19 +47,7 @@
 <body>
     <div class="container">
         <div class="form-container">
-            <h1>Insurance Login</h1>
-            <form method="post" action="/login">
-                {% csrf_token %}
-                <div class="form-group">
-                    <label for="username">Username</label>
-                    <input type="text" id="username" name="username" placeholder="Enter your username" required>
-                </div>
-                <div class="form-group">
-                    <label for="password">Password</label>
-                    <input type="password" id="password" name "password" placeholder="Enter your password" required>
-                </div>
-                <button type="submit">Log In</button>
-            </form>
+            <h1>Login with Affinidi Login</h1>
             <form method="post" action="/login">
               {% csrf_token %} <!-- Include the CSRF token in the form -->
               <div class="affinidi-login-div">

--- a/generator/django/template/django_reference_app/templates/loggedin.html
+++ b/generator/django/template/django_reference_app/templates/loggedin.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <title>Django Affinidi Integration Example</title>
+  <title>Affinidi Login Integration Example</title>
 </head>
 <body>
   <h1>Welcome {{session.email}}!</h1>

--- a/generator/django/template/django_reference_app/urls.py
+++ b/generator/django/template/django_reference_app/urls.py
@@ -22,5 +22,5 @@ urlpatterns = [
     path("", views.index, name="index"),
     path("login", views.login, name="login"),
     path("logout", views.logout, name="logout"),
-    path("auth/", views.auth, name="auth")
+    path("callback", views.callback, name="callback"),
 ]

--- a/generator/django/template/django_reference_app/views.py
+++ b/generator/django/template/django_reference_app/views.py
@@ -3,7 +3,6 @@ from authlib.integrations.django_client import OAuth
 from django.conf import settings
 from django.shortcuts import redirect, render, redirect
 from django.urls import reverse
-from urllib.parse import quote_plus, urlencode
 
 oauth = OAuth()
 
@@ -19,10 +18,10 @@ oauth.register(
 )
 
 def login(request):
-    redirect_uri = request.build_absolute_uri(reverse('auth'))
+    redirect_uri = request.build_absolute_uri(reverse('callback'))
     return oauth.affinidi.authorize_redirect(request, redirect_uri)
 
-def auth(request):
+def callback(request):
     token = oauth.affinidi.authorize_access_token(request)
     request.session["user"] = token['userinfo']
     return redirect(request.build_absolute_uri(reverse("index")))

--- a/generator/django/template/docs/setup-login-config.md
+++ b/generator/django/template/docs/setup-login-config.md
@@ -33,7 +33,7 @@ Follow the guide below if you haven’t installed yet
 `--redirect-uris` will be the URL where the user will be redirected after successful authorization.
 
 - If you are using Affinidi directly without an identity provider, it should be a URL to your app
-  - In Django it would be `http://localhost:{port_number}/auth/`
+  - In Django it would be `http://localhost:8000/callback`
 - If you are using Auth0 as an identity provider it would be `https://{auth0_domain}/login/callback`
 
 Sample response:

--- a/generator/django/template/requirements.txt
+++ b/generator/django/template/requirements.txt
@@ -1,4 +1,4 @@
-Django
-Authlib
-requests
-python-dotenv
+Django==4.2.6
+Authlib==1.2.1
+requests==2.31.0
+python-dotenv==1.0.0

--- a/samples/affinidi-django-authlib/.gitignore
+++ b/samples/affinidi-django-authlib/.gitignore
@@ -1,0 +1,15 @@
+# Python
+__pycache__/
+*.py[cod]
+
+# Django
+db.sqlite3
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/samples/affinidi-django-authlib/README.md
+++ b/samples/affinidi-django-authlib/README.md
@@ -16,9 +16,9 @@ Install the required dependencies:
 pip install -r requirements.txt
 ```
 
-## Create Login Configuration and Update .env
+## Create Login Configuration and update .env
 
-Create your Affinidi OAuth Client at [Affinidi Portal](https://portal.affinidi.com/), make sure to add `http://localhost:{port_number}/auth/` into Authorized redirect URIs.
+Create your Affinidi Login Configuration with the [Affinidi CLI](https://github.com/affinidi/affinidi-cli#set-up-affinidi-login-for-your-applications) or at [Affinidi Portal](https://portal.affinidi.com/), make sure to add `http://localhost:8000/callback` into authorized redirect URIs.
 
 Please read the [setup login config guide](./docs/setup-login-config.md) to understand more about setting up login configuration.
 
@@ -27,7 +27,7 @@ Fill the client ID, secret and issuer URL in `.env` file
 then run:
 
 ```
-python3 manage.py migrate
+python manage.py migrate
 ```
 
 ## Run
@@ -35,10 +35,10 @@ python3 manage.py migrate
 Start server with:
 
 ```
-python3 manage.py runserver
+python manage.py runserver
 ```
 
-Then visit: http://localhost:8000/
+Then visit: http://localhost:8000
 
 ## Read More
 

--- a/samples/affinidi-django-authlib/django_reference_app/settings.py
+++ b/samples/affinidi-django-authlib/django_reference_app/settings.py
@@ -56,7 +56,7 @@ ROOT_URLCONF = 'django_reference_app.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [TEMPLATE_DIR],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -66,7 +66,6 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
             ],
         },
-        'DIRS': [TEMPLATE_DIR],
     },
 ]
 

--- a/samples/affinidi-django-authlib/django_reference_app/templates/index.html
+++ b/samples/affinidi-django-authlib/django_reference_app/templates/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>Django Affinidi Integration Example</title>
+    <title>Affinidi Login Integration Example</title>
     <style>
         .container {
             width: 400px;
@@ -16,32 +16,6 @@
 
         .form-container h1 {
             text-align: center;
-        }
-
-        .form-group {
-            margin-bottom: 15px;
-            margin-right: 10px;
-        }
-
-        .form-group label {
-            display: block;
-        }
-
-        .form-group input {
-            width: 100%;
-            padding: 10px;
-            border: 1px solid #ccc;
-            border-radius: 5px;
-        }
-
-        .form-group button {
-            width: 100%;
-            padding: 10px;
-            background: #007bff;
-            border: none;
-            color: #fff;
-            border-radius: 5px;
-            cursor: pointer;
         }
         
         .affinidi-login-div {
@@ -73,19 +47,7 @@
 <body>
     <div class="container">
         <div class="form-container">
-            <h1>Insurance Login</h1>
-            <form method="post" action="/login">
-                {% csrf_token %}
-                <div class="form-group">
-                    <label for="username">Username</label>
-                    <input type="text" id="username" name="username" placeholder="Enter your username" required>
-                </div>
-                <div class="form-group">
-                    <label for="password">Password</label>
-                    <input type="password" id="password" name "password" placeholder="Enter your password" required>
-                </div>
-                <button type="submit">Log In</button>
-            </form>
+            <h1>Login with Affinidi Login</h1>
             <form method="post" action="/login">
               {% csrf_token %} <!-- Include the CSRF token in the form -->
               <div class="affinidi-login-div">

--- a/samples/affinidi-django-authlib/django_reference_app/templates/loggedin.html
+++ b/samples/affinidi-django-authlib/django_reference_app/templates/loggedin.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <title>Django Affinidi Integration Example</title>
+  <title>Affinidi Login Integration Example</title>
 </head>
 <body>
   <h1>Welcome {{session.email}}!</h1>

--- a/samples/affinidi-django-authlib/django_reference_app/urls.py
+++ b/samples/affinidi-django-authlib/django_reference_app/urls.py
@@ -22,5 +22,5 @@ urlpatterns = [
     path("", views.index, name="index"),
     path("login", views.login, name="login"),
     path("logout", views.logout, name="logout"),
-    path("auth/", views.auth, name="auth")
+    path("callback", views.callback, name="callback"),
 ]

--- a/samples/affinidi-django-authlib/django_reference_app/views.py
+++ b/samples/affinidi-django-authlib/django_reference_app/views.py
@@ -3,7 +3,6 @@ from authlib.integrations.django_client import OAuth
 from django.conf import settings
 from django.shortcuts import redirect, render, redirect
 from django.urls import reverse
-from urllib.parse import quote_plus, urlencode
 
 oauth = OAuth()
 
@@ -19,10 +18,10 @@ oauth.register(
 )
 
 def login(request):
-    redirect_uri = request.build_absolute_uri(reverse('auth'))
+    redirect_uri = request.build_absolute_uri(reverse('callback'))
     return oauth.affinidi.authorize_redirect(request, redirect_uri)
 
-def auth(request):
+def callback(request):
     token = oauth.affinidi.authorize_access_token(request)
     request.session["user"] = token['userinfo']
     return redirect(request.build_absolute_uri(reverse("index")))

--- a/samples/affinidi-django-authlib/docs/setup-login-config.md
+++ b/samples/affinidi-django-authlib/docs/setup-login-config.md
@@ -33,7 +33,7 @@ Follow the guide below if you haven’t installed yet
 `--redirect-uris` will be the URL where the user will be redirected after successful authorization.
 
 - If you are using Affinidi directly without an identity provider, it should be a URL to your app
-  - In Django it would be `http://localhost:{port_number}/auth/`
+  - In Django it would be `http://localhost:8000/callback`
 - If you are using Auth0 as an identity provider it would be `https://{auth0_domain}/login/callback`
 
 Sample response:

--- a/samples/affinidi-django-authlib/requirements.txt
+++ b/samples/affinidi-django-authlib/requirements.txt
@@ -1,4 +1,4 @@
-Django
-Authlib
-requests
-python-dotenv
+Django==4.2.6
+Authlib==1.2.1
+requests==2.31.0
+python-dotenv==1.0.0

--- a/samples/auth0-django-authlib/.gitignore
+++ b/samples/auth0-django-authlib/.gitignore
@@ -1,0 +1,15 @@
+# Python
+__pycache__/
+*.py[cod]
+
+# Django
+db.sqlite3
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/samples/auth0-django-authlib/README.md
+++ b/samples/auth0-django-authlib/README.md
@@ -16,11 +16,12 @@ Install the required dependencies:
 pip install -r requirements.txt
 ```
 
-## Create Login Configuration and Update .env
+## Create Login Configuration and update .env
 
-Create your Affinidi OAuth Client at [Affinidi Portal](https://portal.affinidi.com/), make sure to add `https://{tenant-name}.us.auth0.com/login/callback` into Authorized redirect URIs.
+Create your Affinidi Login Configuration with the [Affinidi CLI](https://github.com/affinidi/affinidi-cli#set-up-affinidi-login-for-your-applications) or at [Affinidi Portal](https://portal.affinidi.com/), make sure to add `https://{tenant-name}.us.auth0.com/login/callback` into authorized redirect URIs.
 
 Please read the [setup login config guide](./docs/setup-login-config.md) to understand more about setting up login configuration in affinidi for Auth0.
+
 Also please refer the [configuration guide](./docs/configuration.md) to understand more about setting up login configuration in Auth0.
 
 Fill the client ID, secret and issuer URL in `.env` file
@@ -28,7 +29,7 @@ Fill the client ID, secret and issuer URL in `.env` file
 then run:
 
 ```
-python3 manage.py migrate
+python manage.py migrate
 ```
 
 ## Run
@@ -36,10 +37,10 @@ python3 manage.py migrate
 Start server with:
 
 ```
-python3 manage.py runserver
+python manage.py runserver
 ```
 
-Then visit: http://localhost:8000/
+Then visit: http://localhost:8000
 
 ## Read More
 

--- a/samples/auth0-django-authlib/django_reference_app/settings.py
+++ b/samples/auth0-django-authlib/django_reference_app/settings.py
@@ -56,7 +56,7 @@ ROOT_URLCONF = 'django_reference_app.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [TEMPLATE_DIR],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -66,7 +66,6 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
             ],
         },
-        'DIRS': [TEMPLATE_DIR],
     },
 ]
 

--- a/samples/auth0-django-authlib/django_reference_app/templates/index.html
+++ b/samples/auth0-django-authlib/django_reference_app/templates/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>Django Affinidi Integration Example</title>
+    <title>Affinidi Login Integration Example</title>
     <style>
         .container {
             width: 400px;
@@ -17,48 +17,14 @@
         .form-container h1 {
             text-align: center;
         }
-
-        .form-group {
-            margin-bottom: 15px;
-            margin-right: 10px;
-        }
-
-        .form-group label {
-            display: block;
-        }
-
-        .form-group input {
-            width: 100%;
-            padding: 10px;
-            border: 1px solid #ccc;
-            border-radius: 5px;
-        }
-
-        .form-group button {
-            width: 100%;
-            padding: 10px;
-            background: #007bff;
-            border: none;
-            color: #fff;
-            border-radius: 5px;
-            cursor: pointer;
-        }
     </style>
 </head>
 <body>
     <div class="container">
         <div class="form-container">
-            <h1>Insurance Login</h1>
+            <h1>Login with Affinidi Login through Auth0</h1>
             <form method="post" action="/login">
                 {% csrf_token %}
-                <div class="form-group">
-                    <label for="username">Username</label>
-                    <input type="text" id="username" name="username" placeholder="Enter your username">
-                </div>
-                <div class="form-group">
-                    <label for="password">Password</label>
-                    <input type="password" id="password" name "password" placeholder="Enter your password">
-                </div>
                 <button type="submit">Log In</button>
             </form>
         </div>

--- a/samples/auth0-django-authlib/django_reference_app/templates/loggedin.html
+++ b/samples/auth0-django-authlib/django_reference_app/templates/loggedin.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <title>Django Affinidi Integration Example</title>
+  <title>Affinidi Login Integration Example</title>
 </head>
 <body>
   <h1>Welcome {{session.userinfo.name}}!</h1>

--- a/samples/auth0-django-authlib/docs/configuration.md
+++ b/samples/auth0-django-authlib/docs/configuration.md
@@ -66,9 +66,9 @@ PROVIDER_ISSUER="https://my-fancy-project.eu.auth0.com"
 
 1.6. Scroll down and set:
 
-- **Allowed Callback URLs** to `http://localhost:{port_number}/callback`
-- **Allowed Logout URLs** to `http://localhost:{port_number}`
-- **Allowed Web Origins** to `http://localhost:{port_number}`
+- **Allowed Callback URLs** to `http://localhost:8000/callback`
+- **Allowed Logout URLs** to `http://localhost:8000`
+- **Allowed Web Origins** to `http://localhost:8000`
 
 ![Callback configuration](./images/auth0_callback_configuration.png)
 
@@ -118,11 +118,3 @@ function fetchUserProfile(accessToken, context, callback) {
 3.4. Click **"Create"** and enable the connection for your application.
 
 ![Enable connection](./images/auth0_enable_connection.png)
-
-3.5. (Optional) Set the connection name in the reference application
-
-Setting this environment variable will allow you to bypass Auth0's window for selecting the social connector. Set this variable to the name you assigned to your social connector on the step 3.1.
-
-```ini
-NEXT_PUBLIC_SOCIAL_CONNECTOR_NAME="Affinidi"
-```

--- a/samples/auth0-django-authlib/docs/setup-login-config.md
+++ b/samples/auth0-django-authlib/docs/setup-login-config.md
@@ -33,7 +33,7 @@ Follow the guide below if you haven’t installed yet
 `--redirect-uris` will be the URL where the user will be redirected after successful authorization.
 
 - If you are using Affinidi directly without an identity provider, it should be a URL to your app
-  - In Django it would be `http://localhost:{port_number}/auth/`
+  - In Django it would be `http://localhost:8000/callback`
 - If you are using Auth0 as an identity provider it would be `https://{auth0_domain}/login/callback`
 
 Sample response:

--- a/samples/auth0-django-authlib/requirements.txt
+++ b/samples/auth0-django-authlib/requirements.txt
@@ -1,4 +1,4 @@
-Django
-Authlib
-requests
-python-dotenv
+Django==4.2.6
+Authlib==1.2.1
+requests==2.31.0
+python-dotenv==1.0.0


### PR DESCRIPTION
Django samples improvements:
- Removed username and password from login views
- In Affinidi provider renamed `auth/` endpoint to `callback` to keep it consistent with other samples
- Froze pip requirement versions
- Added `.gitignore`
- Documentation changes:
  - Use `python` instead of `python3` to keep it consistent with `pip`
  - Fixed to default port `8000` for easy copy