### PR TITLE
fix: dotnet reference app fix cookie mode changed to Lax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ keys
 generator/dotnet/template/obj/
 samples/affinidi-dotnet-openidconnect/obj/
 reference-app-affinidi-vault.sln
+samples/affinidi-dotnet-openidconnect/affinidi-dotnet-openidconnect.sln

--- a/generator/dotnet/template/Startup.cs
+++ b/generator/dotnet/template/Startup.cs
@@ -45,13 +45,13 @@ public class Startup
             .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme, options => {
                 
                 // Use the strongest setting in production, which also enables HTTP on developer workstations
-                options.Cookie.SameSite = SameSiteMode.Strict;
+                options.Cookie.SameSite = SameSiteMode.Lax;
             })
             .AddOpenIdConnect(options => {
 
                 // Use the same settings for temporary cookies
-                options.NonceCookie.SameSite = SameSiteMode.Strict;
-                options.CorrelationCookie.SameSite = SameSiteMode.Strict;
+                options.NonceCookie.SameSite = SameSiteMode.Lax;
+                options.CorrelationCookie.SameSite = SameSiteMode.Lax;
                 options.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 
                 // Set the main OpenID Connect settings

--- a/samples/affinidi-dotnet-openidconnect/Startup.cs
+++ b/samples/affinidi-dotnet-openidconnect/Startup.cs
@@ -45,13 +45,13 @@ public class Startup
             .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme, options => {
                 
                 // Use the strongest setting in production, which also enables HTTP on developer workstations
-                options.Cookie.SameSite = SameSiteMode.Strict;
+                options.Cookie.SameSite = SameSiteMode.Lax;
             })
             .AddOpenIdConnect(options => {
 
                 // Use the same settings for temporary cookies
-                options.NonceCookie.SameSite = SameSiteMode.Strict;
-                options.CorrelationCookie.SameSite = SameSiteMode.Strict;
+                options.NonceCookie.SameSite = SameSiteMode.Lax;
+                options.CorrelationCookie.SameSite = SameSiteMode.Lax;
                 options.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 
                 // Set the main OpenID Connect settings


### PR DESCRIPTION
Due to strict cookie mode, cookies were not being used during auth redirection and it prevented in creating a user session at sit 
Changed strict mode to Lax to allow cookies during redirection. 